### PR TITLE
Replace deprecated Counter.Set with Gauge.Set

### DIFF
--- a/namenode_exporter.go
+++ b/namenode_exporter.go
@@ -32,10 +32,10 @@ type Exporter struct {
 	CorruptBlocks            prometheus.Gauge
 	ExcessBlocks             prometheus.Gauge
 	StaleDataNodes           prometheus.Gauge
-	pnGcCount                prometheus.Counter
-	pnGcTime                 prometheus.Counter
-	cmsGcCount               prometheus.Counter
-	cmsGcTime                prometheus.Counter
+	pnGcCount                prometheus.Gauge
+	pnGcTime                 prometheus.Gauge
+	cmsGcCount               prometheus.Gauge
+	cmsGcTime                prometheus.Gauge
 	heapMemoryUsageCommitted prometheus.Gauge
 	heapMemoryUsageInit      prometheus.Gauge
 	heapMemoryUsageMax       prometheus.Gauge
@@ -95,22 +95,22 @@ func NewExporter(url string) *Exporter {
 			Name:      "StaleDataNodes",
 			Help:      "StaleDataNodes",
 		}),
-		pnGcCount: prometheus.NewCounter(prometheus.CounterOpts{
+		pnGcCount: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "ParNew_CollectionCount",
 			Help:      "ParNew GC Count",
 		}),
-		pnGcTime: prometheus.NewCounter(prometheus.CounterOpts{
+		pnGcTime: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "ParNew_CollectionTime",
 			Help:      "ParNew GC Time",
 		}),
-		cmsGcCount: prometheus.NewCounter(prometheus.CounterOpts{
+		cmsGcCount: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "ConcurrentMarkSweep_CollectionCount",
 			Help:      "ConcurrentMarkSweep GC Count",
 		}),
-		cmsGcTime: prometheus.NewCounter(prometheus.CounterOpts{
+		cmsGcTime: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "ConcurrentMarkSweep_CollectionTime",
 			Help:      "ConcurrentMarkSweep GC Time",

--- a/resourcemanager_exporter.go
+++ b/resourcemanager_exporter.go
@@ -35,8 +35,8 @@ type Exporter struct {
 	appsFailed            prometheus.Gauge
 	appsRunning           prometheus.Gauge
 	appsPending           prometheus.Gauge
-	appsCompleted         prometheus.Counter
-	appsSubmitted         prometheus.Counter
+	appsCompleted         prometheus.Gauge
+	appsSubmitted         prometheus.Gauge
 	allocatedMB           prometheus.Gauge
 	reservedVirtualCores  prometheus.Gauge
 	availableVirtualCores prometheus.Gauge
@@ -115,12 +115,12 @@ func NewExporter(url string) *Exporter {
 			Name:      "appsPending",
 			Help:      "appsPending",
 		}),
-		appsCompleted: prometheus.NewCounter(prometheus.CounterOpts{
+		appsCompleted: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "appsCompleted",
 			Help:      "appsCompleted",
 		}),
-		appsSubmitted: prometheus.NewCounter(prometheus.CounterOpts{
+		appsSubmitted: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Name:      "appsSubmitted",
 			Help:      "appsSubmitted",


### PR DESCRIPTION
Tried to build hadoop_exporter against the master of prometheus/client_golang, but it failed with the following error:

```
$ go build namenode_exporter.go
# command-line-arguments
./namenode_exporter.go:243:15: e.pnGcCount.Set undefined (type prometheus.Counter has no field or method Set)
./namenode_exporter.go:244:14: e.pnGcTime.Set undefined (type prometheus.Counter has no field or method Set)
./namenode_exporter.go:247:16: e.cmsGcCount.Set undefined (type prometheus.Counter has no field or method Set)
./namenode_exporter.go:248:15: e.cmsGcTime.Set undefined (type prometheus.Counter has no field or method Set)
```

```
$ go build resourcemanager_exporter.go 
# command-line-arguments
./resourcemanager_exporter.go:256:17: e.appsCompleted.Set undefined (type prometheus.Counter has no field or method Set)
./resourcemanager_exporter.go:257:17: e.appsSubmitted.Set undefined (type prometheus.Counter has no field or method Set)
```

This is because `Set` method for `Counter` type has been removed on the master.

https://github.com/prometheus/client_golang/pull/247/commits/2fee50beaa152342e8347c41edf2202c3bd5f858

I think there's no problem if we use `Gauge` for these metrics instead of `Counter`.