### PR TITLE
Prevent crash on http get failure

### DIFF
--- a/namenode_exporter.go
+++ b/namenode_exporter.go
@@ -172,6 +172,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	resp, err := http.Get(e.url)
 	if err != nil {
 		log.Error(err)
+		return
 	}
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)

--- a/resourcemanager_exporter.go
+++ b/resourcemanager_exporter.go
@@ -200,6 +200,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	resp, err := http.Get(e.url + "/ws/v1/cluster/metrics")
 	if err != nil {
 		log.Error(err)
+		return
 	}
 	defer resp.Body.Close()
 	data, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Prevent exporter from crashing if it is unable to contact namenode/resourcemanager. 

Currently if the exporter is started before the namenode/resourcemanager has had time to start, and is scraped by prometheus, it will crash on:

```defer resp.Body.Close()```

This change just returns immediately from the error, preventing the crash. 
