### PR TITLE
Updated deprecated prometheus.Handler to promhttp.Handler

### DIFF
--- a/resourcemanager_exporter.go
+++ b/resourcemanager_exporter.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/log"
 )
 
@@ -297,7 +298,7 @@ func main() {
 	prometheus.MustRegister(exporter)
 
 	log.Printf("Starting Server: %s", *listenAddress)
-	http.Handle(*metricsPath, prometheus.Handler())
+	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
 		<head><title>ResourceManager Exporter</title></head>


### PR DESCRIPTION
prometheus.Handler is deprecated and giving an error in new versions 

"undefined: prometheus.Handler"

Updated this with new promhttp.Handler

Reference : https://prometheus.io/docs/guides/go-application/